### PR TITLE
Fix: 타임라인 각 tweet의 user avatar image 에러 해결

### DIFF
--- a/src/components/tweets/post-tweet-form.tsx
+++ b/src/components/tweets/post-tweet-form.tsx
@@ -42,8 +42,9 @@ export default function PostTweetForm({ labelId }: { labelId: string }) {
       const doc = await addDoc(collection(db, "tweets"), {
         tweet,
         createdAt: Date.now(),
-        username: user.displayName || "익명",
-        userId: user.uid,
+        creatorName: user.displayName || "익명",
+        creatorId: user.uid,
+        creatorAvatar: user.photoURL,
       });
       if (img && img?.length > 0) {
         const locationRef = ref(storage, `tweets/${user.uid}/${doc.id}`);

--- a/src/components/tweets/timeline.tsx
+++ b/src/components/tweets/timeline.tsx
@@ -14,8 +14,9 @@ import { Unsubscribe } from "firebase/auth";
 export interface ITweet {
   id: string;
   tweet: string;
-  userId: string;
-  username: string;
+  creatorId: string;
+  creatorName: string;
+  creatorAvatar?: string;
   photo?: string;
   createdAt: number;
 }
@@ -43,11 +44,19 @@ export default function Timeline() {
 
       unsubscribe = await onSnapshot(tweetsQuery, (snapshot) => {
         const tweets = snapshot.docs.map((doc) => {
-          const { tweet, userId, username, photo, createdAt } = doc.data();
+          const {
+            tweet,
+            creatorId,
+            creatorName,
+            creatorAvatar,
+            photo,
+            createdAt,
+          } = doc.data();
           return {
             tweet,
-            userId,
-            username,
+            creatorId,
+            creatorName,
+            creatorAvatar,
             photo,
             createdAt,
             id: doc.id,

--- a/src/components/tweets/tweet.tsx
+++ b/src/components/tweets/tweet.tsx
@@ -70,7 +70,14 @@ const ProfileImg = styled.img`
   overflow: hidden;
 `;
 
-export default function Tweet({ username, userId, photo, tweet, id }: ITweet) {
+export default function Tweet({
+  creatorId,
+  creatorName,
+  creatorAvatar,
+  photo,
+  tweet,
+  id,
+}: ITweet) {
   const user = auth.currentUser;
 
   return (
@@ -78,20 +85,20 @@ export default function Tweet({ username, userId, photo, tweet, id }: ITweet) {
       <Row>
         <Col>
           <ProfilePic>
-            {user?.photoURL ? (
+            {creatorAvatar ? (
               <ProfileImg
-                alt={`${user?.displayName}의 profile image`}
-                src={user?.photoURL || ""}
+                alt={`${creatorName}의 profile image`}
+                src={creatorAvatar || ""}
               />
             ) : null}
           </ProfilePic>
         </Col>
         <Col>
-          <UserName>{username}</UserName>
-          <UserId>{`@${userId.slice(0, 10)}`}</UserId>
+          <UserName>{creatorName}</UserName>
+          <UserId>{`@${creatorId.slice(0, 10)}`}</UserId>
         </Col>
         <Col>
-          {user?.uid === userId ? (
+          {user?.uid === creatorId ? (
             <>
               <DeleteTweetAlert id={id} photo={photo} />
               <EditTweetDialog id={id} />


### PR DESCRIPTION
- 에러
  - 타임라인의 각 tweet의 user avatar image가 현재 로그인 된 user의 avatar image로 보이는 에러
- 해결 방법
  - tweets collection에 creatorAvatar field를 추가하여 avatar image url 저장
  - tweets collection의 field 명 변경
    - userId -> creatorId
    - username -> creatorName